### PR TITLE
Display Player 1-8 instead of Player 0-7

### DIFF
--- a/swiss.rb
+++ b/swiss.rb
@@ -7,7 +7,7 @@ class Swiss
     self.players = {}
     self.used_pairs = []
     num_players.times do |i|
-      puts "Name of player #{i}?"
+      puts "Name of player #{i+1}?"
       name = gets.chomp
       self.players[i] = { name: name, match_points: 0, game_points: 0 }
     end


### PR DESCRIPTION
Tiny UX fix: instead of player 0-7, this change will print out player 1-8, which is marginally more friendly to non-developers.
